### PR TITLE
Allow setting of the rootdn

### DIFF
--- a/manifests/server/master.pp
+++ b/manifests/server/master.pp
@@ -1,5 +1,6 @@
 
 class ldap::server::master($suffix, $rootpw,
+        $rootdn              = "cn=admin,$suffix",
 	$schema_inc          = [],
 	$modules_inc         = [],
 	$index_inc           = [],

--- a/templates/redhat/etc/openldap/slapd.conf.erb
+++ b/templates/redhat/etc/openldap/slapd.conf.erb
@@ -50,7 +50,7 @@ backend		bdb
 database	bdb
 suffix		"<%= suffix %>"
 directory	<%= db_prefix %>
-rootdn		"cn=admin,<%= suffix %>"
+rootdn		"<%= rootdn %>"
 rootpw		"<%= rootpw %>"
 
 #######################################################################


### PR DESCRIPTION
currently the rootdn will always be cn=admin. In our case we want a different rootdn. This patch allow us to do that.
