### PR TITLE
Fix provider problem

### DIFF
--- a/manifests/server/master.pp
+++ b/manifests/server/master.pp
@@ -205,9 +205,10 @@ class ldap::server::master(
 
     # Create certificate hash file
     exec { "Server certificate hash":
-      command => "ln -s ${ldap::params::ssl_prefix}/${ssl_cert} ${ldap::params::cacertdir}/$(openssl x509 -noout -hash -in ${ldap::params::ssl_prefix}/${ssl_cert}).0",
-      unless  => "test -f ${ldap::params::cacertdir}/$(openssl x509 -noout -hash -in ${ldap::params::ssl_prefix}/${ssl_cert}).0",
-      require => File['ssl_cert']
+      command  => "ln -s ${ldap::params::ssl_prefix}/${ssl_cert} ${ldap::params::cacertdir}/$(openssl x509 -noout -hash -in ${ldap::params::ssl_prefix}/${ssl_cert}).0",
+      unless   => "test -f ${ldap::params::cacertdir}/$(openssl x509 -noout -hash -in ${ldap::params::ssl_prefix}/${ssl_cert}).0",
+      provider => 'shell',
+      require  => File['ssl_cert']
     }
 
     


### PR DESCRIPTION
With puppet 3.2.2 this gives an error as the default
provider of POSIX doesn't expand the subshell $()

Otherwise you get an error like this: 
Error: Failed to apply catalog: Parameter unless failed on Exec[Server certificate hash]: 'test -f /etc/openldap/cacerts/$(openssl x509 -noout -hash -in /etc/openldap/cacerts/ldapserver.pem).0' is not qualified and no path was specified. Please qualify the command or specify a path. at /etc/puppet/modules/ldap/manifests/server/master.pp:211
