### PR TITLE
rootpw, rootdn and suffix can be configured using ldap tools

### DIFF
--- a/manifests/server/master.pp
+++ b/manifests/server/master.pp
@@ -199,6 +199,16 @@ class ldap::server::master(
       }
   }
 
+	file {"${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif" :
+    ensure  => present,
+		content => template("ldap/${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif"),
+		require => Service[$ldap::params::service],
+	}
+
+	exec{"/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif && rm -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif":
+	  require => File["${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif"],
+	}
+
   $msg_prefix = 'SSL enabled. You must specify'
   $msg_suffix = '(filename). It should be located at puppet:///files/ldap'
 

--- a/manifests/server/master.pp
+++ b/manifests/server/master.pp
@@ -170,8 +170,14 @@ class ldap::server::master(
       require => Service[$ldap::params::service],
     }
 
-    exec{"/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config-update.ldif && rm -f ${ldap::params::prefix}/slapd.d/cn=config-update.ldif":
-      require => File["${ldap::params::prefix}/slapd.d/cn=config-update.ldif"],
+    exec{"/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config-update.ldif":
+      require   => File["${ldap::params::prefix}/slapd.d/cn=config-update.ldif"],
+			tries		  => 10,
+			try_sleep => 1,
+    }
+
+    exec{"/bin/rm -f ${ldap::params::prefix}/slapd.d/cn=config-update.ldif":
+      require => Exec["/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config-update.ldif"],
     }
 
   }
@@ -205,8 +211,14 @@ class ldap::server::master(
 		require => Service[$ldap::params::service],
 	}
 
-	exec{"/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif && rm -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif":
-	  require => File["${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif"],
+	exec{"/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif":
+	  require     => File["${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif"],
+		tries       => 10,
+		try_sleep   => 1,
+	}
+
+	exec{"/bin/rm -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif":
+	  require => Exec["/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif"],
 	}
 
   $msg_prefix = 'SSL enabled. You must specify'

--- a/manifests/server/slave.pp
+++ b/manifests/server/slave.pp
@@ -252,6 +252,16 @@ class ldap::server::slave(
       }
   }
 
+  file {"${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif" :
+    ensure  => present,
+    content => template("ldap/${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif"),
+	require => Service[$ldap::params::service],
+  }
+
+  exec{"/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif && rm -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif":
+    require => File["${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif"],
+  }
+
   $msg_prefix = 'SSL enabled. You must specify'
   $msg_suffix = '(filename). It should be located at puppet:///files/ldap'
 

--- a/manifests/server/slave.pp
+++ b/manifests/server/slave.pp
@@ -223,8 +223,14 @@ class ldap::server::slave(
       require => Service[$ldap::params::service],
     }
 
-    exec{"/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config-update.ldif && rm -f ${ldap::params::prefix}/slapd.d/cn=config-update.ldif":
-      require => File["${ldap::params::prefix}/slapd.d/cn=config-update.ldif"],
+    exec{"/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config-update.ldif":
+      require   => File["${ldap::params::prefix}/slapd.d/cn=config-update.ldif"],
+      tries		=> 10,
+      try_sleep => 1,
+    }
+
+    exec{"/bin/rm -f ${ldap::params::prefix}/slapd.d/cn=config-update.ldif":
+      require => Exec["/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config-update.ldif"],
     }
 
   }
@@ -258,8 +264,14 @@ class ldap::server::slave(
 	require => Service[$ldap::params::service],
   }
 
-  exec{"/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif && rm -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif":
-    require => File["${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif"],
+  exec{"/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif":
+    require     => File["${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif"],
+	tries       => 10,
+	try_sleep   => 1,
+  }
+  
+  exec{"/bin/rm -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif":
+    require => Exec["/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f ${ldap::params::prefix}/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif"],
   }
 
   $msg_prefix = 'SSL enabled. You must specify'

--- a/templates/etc/openldap/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif
+++ b/templates/etc/openldap/slapd.d/cn=config/olcDatabase={2}bdb-update.ldif
@@ -1,0 +1,11 @@
+dn: olcDatabase={2}bdb,cn=config
+changetype: modify
+replace: olcSuffix
+olcSuffix: <%= @suffix %>
+-
+replace: olcRootDN
+olcRootDN: <%= @rootdn %>
+-
+replace: olcRootPW
+olcRootPW: <%= @rootpw %> 
+-


### PR DESCRIPTION
Following on the migration to OpenLDAP v3, now rootpw, rootdn
and suffix of the main bdb can be configured using the v3 ldap
way over the slapd.conf
