### PR TITLE
Updated the README.md to account for class reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Puppet module to manage client and server configuration for
 Ldap client configuration at its simplest:
 
 
-    class { 'ldap':
+    class { 'ldap::client':
     	uri  => 'ldap://ldapserver00 ldap://ldapserver01',
     	base => 'dc=foo,dc=bar'
     }
@@ -25,7 +25,7 @@ Enable TLS/SSL:
 Note that *ssl_cert* should be the CA's certificate file, and
 it should be located under *puppet:///files/ldap/*.
 
-    class { 'ldap':
+    class { 'ldap::client':
     	uri      => 'ldap://ldapserver00 ldap://ldapserver01',
     	base     => 'dc=foo,dc=bar',
     	ssl      => true,
@@ -34,7 +34,7 @@ it should be located under *puppet:///files/ldap/*.
 
 Enable nsswitch and pam configuration (requires both modules):
 
-    class { 'ldap':
+    class { 'ldap::client':
       uri      => 'ldap://ldapserver00 ldap://ldapserver01',
       base     => 'dc=foo,dc=bar',
       ssl      => true


### PR DESCRIPTION
When invoking the client parts of the module, the class should be invoked
as ldap::client instead of as ldap.
