### PR TITLE
Adding centos.pp class to fix error found during puppet run

### DIFF
--- a/manifests/os/centos.pp
+++ b/manifests/os/centos.pp
@@ -1,0 +1,3 @@
+# == Class: ldap::os::centos
+#
+class ldap::os::centos {}


### PR DESCRIPTION
W/o this class, I get errors during a puppet run on a Centos 6.5 master and agent

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Could not find class ldap::os::CentOS for host01.c.com on node host01.c.com
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
